### PR TITLE
Remove older docker images after the new image is built

### DIFF
--- a/Build/build.sh
+++ b/Build/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 git submodule update --init --recursive
 IMAGE_NAME="$(whoami)-rzg2l_vlp_v3.0.0"
-docker image rm ${IMAGE_NAME} || (echo "Image ${IMAGE_NAME} didn't exist so not cleaned."; exit 0)
 docker build -t ${IMAGE_NAME}:latest .
+docker rmi $(docker images | grep "^<none" | awk '{print $3}')


### PR DESCRIPTION
I learned that in the previous code, if I am the only one using the docker, when it removes my older docker image it removed all of the cached layers with it because it was the only image that was using them.

In this pull request, the new image is built first and then the older image (that now has the name <none> in it) is removed.  In this approach, the cached layers are reused in the new image, and they won't get deleted.