### PR TITLE
Two container fixes

### DIFF
--- a/Build/Dockerfile
+++ b/Build/Dockerfile
@@ -27,10 +27,10 @@ RUN wget https://remote.mistywest.io/download/mh11/rzg2l/VerifiedLinuxPackage_v3
 RUN wget https://remote.mistywest.io/download/mh11/rzg2l/VerifiedLinuxPackage_v3.0.0/RTK0EF0045Z13001ZJ-v1.2_EN.zip
 RUN wget https://remote.mistywest.io/download/mh11/rzg2l/VerifiedLinuxPackage_v3.0.0/RTK0EF0045Z15001ZJ-v0.58_EN.zip
 RUN wget https://remote.mistywest.io/download/mh11/rzg2l/VerifiedLinuxPackage_v3.0.0/oss_pkg_v3.0.0.7z
-COPY start.sh /home/yocto/
+RUN apt-get -y install tree wiggle
 COPY exec.sh /home/yocto/
+COPY start.sh /home/yocto/
 RUN chown yocto:yocto -R /home/yocto/
-RUN apt-get -y install tree
 USER yocto
 RUN mkdir -p /home/yocto/rzg_vlp_v3.0.0/build/downloads
 RUN mkdir -p /home/yocto/rzg_vlp_v3.0.0/out

--- a/Build/start.sh
+++ b/Build/start.sh
@@ -2,6 +2,7 @@
 set -e
 #Check hostname is a hexadecimal number of 12 
 LOCALCONF="/home/yocto/rzg_vlp_v3.0.0/build/conf/local.conf"
+YOCTODIR="/home/yocto/rzg_vlp_v3.0.0/"
 hname=`hostname | egrep -o '^[0-9a-f]{12}\b'`
 echo $hname
 len=${#hname}
@@ -56,6 +57,10 @@ then
 fi
 #addition of meta-mistysom layer to bblayers.conf
 sed -i 's/renesas \\/&\n  ${TOPDIR}\/..\/meta-mistysom \\/' /home/yocto/rzg_vlp_v3.0.0/build/conf/bblayers.conf
+
+# add dunfell compatibility to layers wehre they're missing to avoid WARNING
+echo "LAYERSERIES_COMPAT_qt5-layer = \"dunfell\"" >> ${YOCTODIR}/meta-qt5/conf/layer.conf
+echo "LAYERSERIES_COMPAT_rz-features = \"dunfell\"" >> ${YOCTODIR}/meta-rz-features/conf/layer.conf
 
 echo "    ------------------------------------------------
     SETUP SCRIPT BUILD ENVIRONMENT SETUP SUCCESSFUL!


### PR DESCRIPTION
See the two changes below,

1. `start.sh` is setting the `LAYERSERIES_COMPAT` variables in qt5-layer and rz-features layers which prevents `WARNINGS` about it.
2. `Dockerfile`  just moved lines around to optimize order of layer creation when the containers is rebuilt.