### PR TITLE
Script changes & License fix

### DIFF
--- a/Build/build.sh
+++ b/Build/build.sh
@@ -7,4 +7,4 @@ else
 	IMAGE_NAME="$(whoami)-rzg2l_vlp_v3.0.0"
 fi
 docker build -t ${IMAGE_NAME}:latest .
-docker rmi $(docker images | grep "^<none" | awk '{print $3}')
+(docker images | grep "^<none" | awk '{print $3}' | xargs docker rmi) || :

--- a/Build/build.sh
+++ b/Build/build.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 git submodule sync
 git submodule update --init --recursive
-IMAGE_NAME="$(whoami)-rzg2l_vlp_v3.0.0"
+if [ "$1" == "-b" ]; then
+	IMAGE_NAME="$(whoami)-rzg2l_vlp_v3.0.0_$(git branch --show-current)"
+else
+	IMAGE_NAME="$(whoami)-rzg2l_vlp_v3.0.0"
+fi
 docker build -t ${IMAGE_NAME}:latest .
-(docker images | grep "^<none" | awk '{print $3}' | xargs docker rmi) || :
+docker rmi $(docker images | grep "^<none" | awk '{print $3}')

--- a/Build/run.sh
+++ b/Build/run.sh
@@ -11,6 +11,7 @@ usage() {
         $ $0 -v|--verbose       run script in verbose mode"
 
 }
+test -t 1 && USE_TTY="-it"
 #OUTDIR is bind mopunted and will contain the compiled output from the container
 OUTDIR='output'
 MPU="rzg2l"
@@ -61,9 +62,7 @@ then
 else
 	CONTNAME="$(whoami)-rzg2l_vlp_v3.0.0"
 fi
-#Create OUTDIR if iot doesn't exist
-#echo "VERBOSE: ${VERBOSE} NO: ${NO}"
-#exit
+#Create OUTDIR if it doesn't exist
 if [ ! -d "${OUTDIR}" ];
 then
 	mkdir ${OUTDIR}

--- a/Build/run.sh
+++ b/Build/run.sh
@@ -3,15 +3,16 @@
 
 usage() {
     echo "    Usage:
-    $ $0 -c|--cpath : path to local cache (download & sstate)
-    $ $0 -n|--no : starts container but does not invoke bitbake
-    $ $0 -s|--sdk : start in developer mode, 
-                    invokes building of SDK"
+        $ $0 -b|--branch :      attach current branch name when running the container
+        $ $0 -c|--cpath :       path to local cache (download & sstate)
+        $ $0 -n|--no :          starts container but does not invoke bitbake
+        $ $0 -s|--sdk :         start in developer mode, 
+                                      invokes building of SDK
+        $ $0 -v|--verbose       run script in verbose mode"
+
 }
 #OUTDIR is bind mopunted and will contain the compiled output from the container
 OUTDIR='output'
-CONTNAME="$(whoami)-rzg2l_vlp_v3.0.0"
-test -t 1 && USE_TTY="-it"
 MPU="rzg2l"
 str="$*"
 if [[ $str == *"-c"* ]];
@@ -25,6 +26,10 @@ then
 fi
 while [[ $# -gt 0 ]]; do
     case $1 in
+      -b|--branch)
+        BRANCH="1"
+        shift #past argument
+      ;;
       -c|--cpath)
         CPATH="$2"
 	DLOAD="1"
@@ -34,12 +39,14 @@ while [[ $# -gt 0 ]]; do
       -n|--no)
         NO="1"
         shift #past argument
-        shift #past value
       ;;
       -s|--sdk)
         SDK="1"
         shift #past argument
-        shift #past value
+      ;;
+      -v|--verbose)
+        VERBOSE="1"
+        shift #past argument
       ;;
       -*|--*)
         echo "Unknown argument $1"
@@ -48,15 +55,28 @@ while [[ $# -gt 0 ]]; do
         ;;
     esac
 done
+if [ "$BRANCH" == "1" ];
+then
+	CONTNAME="$(whoami)-rzg2l_vlp_v3.0.0_$(git branch --show-current)"
+else
+	CONTNAME="$(whoami)-rzg2l_vlp_v3.0.0"
+fi
 #Create OUTDIR if iot doesn't exist
+#echo "VERBOSE: ${VERBOSE} NO: ${NO}"
+#exit
 if [ ! -d "${OUTDIR}" ];
 then
 	mkdir ${OUTDIR}
 fi
-	chmod 777 ${OUTDIR}
+	if [ -z "${VERBOSE}" ];
+	then
+		chmod 777 ${OUTDIR} 2>/dev/null
+	else
+		chmod 777 ${OUTDIR}
+	fi
 if [ -z "${CPATH}" ]; 
 then
-	/usr/bin/docker run --privileged ${USE_TTY} --rm -e NO=${NO} -e SDK=${SDK} -e DLOAD=${DLOAD} -v "${PWD}/${OUTDIR}":/home/yocto/rzg_vlp_v3.0.0/out --name ${CONTNAME} ${CONTNAME}
+	/usr/bin/docker run --privileged -it -e NO=${NO} -e SDK=${SDK} -e DLOAD=${DLOAD} -v "${PWD}/${OUTDIR}":/home/yocto/rzg_vlp_v3.0.0/out ${CONTNAME}
 else
 	#Create CPATH sub directories if they do not exist
 	if [ ! -d "${CPATH}/downloads" ];
@@ -67,7 +87,13 @@ else
 	then
 		mkdir -p ${CPATH}/sstate-cache/${MPU}
 	fi
-	chmod -R 777 ${CPATH}/downloads
-	chmod -R 777 ${CPATH}/sstate-cache/${MPU}
-	/usr/bin/docker run --privileged ${USE_TTY} --rm -v "${PWD}/${OUTDIR}":/home/yocto/rzg_vlp_v3.0.0/out -v "${CPATH}/downloads":/home/yocto/rzg_vlp_v3.0.0/build/downloads -v "${CPATH}/sstate-cache/${MPU}/":/home/yocto/rzg_vlp_v3.0.0/build/sstate-cache -e NO=${NO} -e SDK=${SDK} -e DLOAD=${DLOAD} --name ${CONTNAME} ${CONTNAME}
+	if [ -z ${VERBOSE} ];
+	then
+		chmod -R 777 ${CPATH}/downloads 2>/dev/null
+		chmod -R 777 ${CPATH}/sstate-cache/${MPU} 2>/dev/null
+	else
+		chmod -R 777 ${CPATH}/downloads
+		chmod -R 777 ${CPATH}/sstate-cache/${MPU}
+	fi
+	/usr/bin/docker run --privileged -it --rm -v "${PWD}/${OUTDIR}":/home/yocto/rzg_vlp_v3.0.0/out -v "${CPATH}/downloads":/home/yocto/rzg_vlp_v3.0.0/build/downloads -v "${CPATH}/sstate-cache/${MPU}/":/home/yocto/rzg_vlp_v3.0.0/build/sstate-cache -e NO=${NO} -e SDK=${SDK} -e DLOAD=${DLOAD} --name ${CONTNAME} ${CONTNAME}
 fi

--- a/Build/run.sh
+++ b/Build/run.sh
@@ -76,7 +76,7 @@ fi
 	fi
 if [ -z "${CPATH}" ]; 
 then
-	/usr/bin/docker run --privileged -it -e NO=${NO} -e SDK=${SDK} -e DLOAD=${DLOAD} -v "${PWD}/${OUTDIR}":/home/yocto/rzg_vlp_v3.0.0/out ${CONTNAME}
+	/usr/bin/docker run --privileged ${USE_TTY} --rm -e NO=${NO} -e SDK=${SDK} -e DLOAD=${DLOAD} -v "${PWD}/${OUTDIR}":/home/yocto/rzg_vlp_v3.0.0/out --name ${CONTNAME} ${CONTNAME}
 else
 	#Create CPATH sub directories if they do not exist
 	if [ ! -d "${CPATH}/downloads" ];
@@ -95,5 +95,5 @@ else
 		chmod -R 777 ${CPATH}/downloads
 		chmod -R 777 ${CPATH}/sstate-cache/${MPU}
 	fi
-	/usr/bin/docker run --privileged -it --rm -v "${PWD}/${OUTDIR}":/home/yocto/rzg_vlp_v3.0.0/out -v "${CPATH}/downloads":/home/yocto/rzg_vlp_v3.0.0/build/downloads -v "${CPATH}/sstate-cache/${MPU}/":/home/yocto/rzg_vlp_v3.0.0/build/sstate-cache -e NO=${NO} -e SDK=${SDK} -e DLOAD=${DLOAD} --name ${CONTNAME} ${CONTNAME}
+	/usr/bin/docker run --privileged ${USE_TTY} --rm -v "${PWD}/${OUTDIR}":/home/yocto/rzg_vlp_v3.0.0/out -v "${CPATH}/downloads":/home/yocto/rzg_vlp_v3.0.0/build/downloads -v "${CPATH}/sstate-cache/${MPU}/":/home/yocto/rzg_vlp_v3.0.0/build/sstate-cache -e NO=${NO} -e SDK=${SDK} -e DLOAD=${DLOAD} --name ${CONTNAME} ${CONTNAME}
 fi

--- a/Build/start.sh
+++ b/Build/start.sh
@@ -39,6 +39,8 @@ NUM_CPU=$(((mem+swp)/1000/1000/4))
 #NUM_CPU=`nproc`
 ##Update number of CPUs in local.conf
 sed -i "1 i\PARALLEL_MAKE = \"-j ${NUM_CPU}\"\nBB_NUMBER_THREADS = \"${NUM_CPU}\"" ${LOCALCONF}
+# Comment out the line that flags GPLv3 as an incompatible license
+sed -i '/^INCOMPATIBLE_LICENSE = \"GPLv3 GPLv3+\"/ s/./#&/' ${LOCALCONF}
 #build offline tools, without network access
 if [ -z $DLOAD ];
 then


### PR DESCRIPTION
Three changes:

1. `build.sh` & `run.sh` get the a `-b` option to append the branch name to the container image name which allows that a user can run multiple images simultaneously if parallel work on multiple branches is done. This has assisted me a few times already.
2. `run.sh` gets a verbose `-v` flag. When run without it, it is a bit quieter as it relates to setting file permissions in the cache directory.
3. `start.sh` comments out the `INCOMPATIBLE_LICENSE = "GPLv3 GPLv3+"` variable in `conf/local.conf` which should prevent nasty warnings to be printed from packages that have the license set to GPLv3.