### PR TITLE
Fix build yocto workflow

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -37,7 +37,7 @@ jobs:
           require_head: true
 
   build-yocto:
-    runs-on: self-hosted
+    runs-on: DC02
     
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
In this pull request, I am narrowing the runner to only DC02 so it wouldn't confuse the new self-hosted runner on DC01 (used for the wiki)