### PR TITLE
Add wic.bz2 image output

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -60,10 +60,5 @@ jobs:
     - name: Upload artifacts
       uses: actions/upload-artifact@v3
       with:
-        name: output-files
-        path: |
-          Build/output/images/smarc-rzg2l/Image-smarc-rzg2l.bin
-          Build/output/images/smarc-rzg2l/r9a07g044l2-smarc.dtb
-          Build/output/images/smarc-rzg2l/r9a07g044l2-smarc-ar0234.dtb
-          Build/output/images/smarc-rzg2l/r9a07g044l2-smarc-imx462.dtb
-          Build/output/images/smarc-rzg2l/mistysom-image-smarc-rzg2l.tar.bz2
+        name: output-image
+        path: rzg2l/Build/output/images/smarc-rzg2l/mistysom-image-smarc-rzg2l.wic.bz2


### PR DESCRIPTION
In this pull request, I am changing the image deploy output to wic.bz2

The reason behind the bz2 additional extension is that the file sizes go beyond 900 MB which is not suitable for download and upload.

The wic.bz2 file can be written into an SD card with the command below which creates two partitions for boot and root:
```
pv mistysom-image-smarc-rzg2l.wic.bz2 | bzcat | sudo dd bs=4M of=/dev/sdX
```