### PR TITLE
Add workflows for release promotion

### DIFF
--- a/.github/workflows/create-pull-request.yml
+++ b/.github/workflows/create-pull-request.yml
@@ -1,0 +1,23 @@
+name: Create release promotion pull request
+on:
+  push:
+    branches:
+      - develop
+jobs:
+  release-promotion:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      # Create a pull request from develop to master
+      - name: Create Pull Request
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr create --base master --head develop \
+            --title "Merge from develop to master" \
+            --body "This is an automated pull request created by GitHub Actions." \
+            --reviewer matinlotfali \
+            --reviewer mistyron

--- a/.github/workflows/master-fast-forward.yml
+++ b/.github/workflows/master-fast-forward.yml
@@ -1,0 +1,23 @@
+name: Fast forward master if develop is approved
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  fast_forward_job:
+    name: Fast Forward
+    if: github.event.pull_request.base.ref == 'master' && github.event.review.state == 'approved'  
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: master
+          fetch-depth: 0
+        
+      - name: Fast Forward PR
+        run: |
+          git merge origin/develop --ff-only
+          git push

--- a/.github/workflows/release-submittion.yml
+++ b/.github/workflows/release-submittion.yml
@@ -1,0 +1,22 @@
+name: Release Submition
+
+on: 
+  push:
+    branches: [master]
+
+jobs:
+  release-submittion:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+    - uses: actions/checkout@v3
+    - uses: ncipollo/release-action@v1.12
+      with:
+        draft: true
+        generateReleaseNotes: true
+        allowUpdates: true
+        repo: master
+        artifactErrorsFailBuild: true
+        replacesArtifacts: true
+        artifacts: "mistysom-image-smarc-rzg2l.wic.bz2"


### PR DESCRIPTION
In this pull request I am adding workflows similar to [#meta-mistysom/](https://github.com/MistySOM/meta-mistysom/pull/37)

The only difference is that the release submission will include the wic.bz2 artifact.