### PR TITLE
Change mistywest.io domain to mistywest.com

### DIFF
--- a/Build/prepare_yocto_env.sh
+++ b/Build/prepare_yocto_env.sh
@@ -1,8 +1,8 @@
 
-wget https://remote.mistywest.io/download/mh11/rzg2l/VerifiedLinuxPackage_v3.0.0/RTK0EF0045Z0021AZJ-v3.0.0-update2.zip
-wget https://remote.mistywest.io/download/mh11/rzg2l/VerifiedLinuxPackage_v3.0.0/RTK0EF0045Z13001ZJ-v1.2_EN.zip
-wget https://remote.mistywest.io/download/mh11/rzg2l/VerifiedLinuxPackage_v3.0.0/RTK0EF0045Z15001ZJ-v0.58_EN.zip
-wget https://remote.mistywest.io/download/mh11/rzg2l/VerifiedLinuxPackage_v3.0.0/oss_pkg_v3.0.0.7z
+wget https://remote.mistywest.com/download/mh11/rzg2l/VerifiedLinuxPackage_v3.0.0/RTK0EF0045Z0021AZJ-v3.0.0-update2.zip
+wget https://remote.mistywest.com/download/mh11/rzg2l/VerifiedLinuxPackage_v3.0.0/RTK0EF0045Z13001ZJ-v1.2_EN.zip
+wget https://remote.mistywest.com/download/mh11/rzg2l/VerifiedLinuxPackage_v3.0.0/RTK0EF0045Z15001ZJ-v0.58_EN.zip
+wget https://remote.mistywest.com/download/mh11/rzg2l/VerifiedLinuxPackage_v3.0.0/oss_pkg_v3.0.0.7z
 
 cd $WORK || exit 1
 


### PR DESCRIPTION
MistyWest has moved away from the domain remote.mistywest.io and started using remote.mistywest.com instead.
Sadly, because we are all using cached states, we forgot to change them.

In this pull request, I am changing them all and we expect all downloads to work as expected.